### PR TITLE
Add season restart flow and archive finished seasons

### DIFF
--- a/src/main/java/com/example/FootballSimulator/FootballMatch/FootballMatchService.java
+++ b/src/main/java/com/example/FootballSimulator/FootballMatch/FootballMatchService.java
@@ -6,7 +6,10 @@ import com.example.FootballSimulator.Constants.Status;
 import com.example.FootballSimulator.FootballPlayer.FootballPlayer;
 import com.example.FootballSimulator.FootballTeam.FootballTeam;
 import com.example.FootballSimulator.FootballTeam.FootballTeamRepository;
+import com.example.FootballSimulator.GameWeek.GameWeek;
 import com.example.FootballSimulator.GameWeek.GameWeekRepository;
+import com.example.FootballSimulator.League.League;
+import com.example.FootballSimulator.League.LeagueRepository;
 import com.example.FootballSimulator.LineUp.LineUp;
 import com.example.FootballSimulator.Standings.Standing;
 import com.example.FootballSimulator.Standings.StandingRepository;
@@ -32,13 +35,17 @@ public class FootballMatchService {
 
     private GameWeekRepository gameWeekRepository;
 
+    private LeagueRepository leagueRepository;
+
     public FootballMatchService(FootballMatchRepository footballMatchRepository, StandingRepository standingsRepository,
-                                UserRepository userRepository, FootballTeamRepository footballTeamRepository, GameWeekRepository gameWeekRepository) {
+                                UserRepository userRepository, FootballTeamRepository footballTeamRepository, GameWeekRepository gameWeekRepository,
+                                LeagueRepository leagueRepository) {
         this.footballMatchRepository = footballMatchRepository;
         this.standingsRepository = standingsRepository;
         this.userRepository = userRepository;
         this.footballTeamRepository = footballTeamRepository;
         this.gameWeekRepository = gameWeekRepository;
+        this.leagueRepository = leagueRepository;
     }
 
     public String viewMatch(Long matchId, Model model) {
@@ -86,6 +93,7 @@ public class FootballMatchService {
             updateMatchAftermath(footballMatch);
             footballMatch.setMatchStatus(Status.FINISHED);
             footballMatchRepository.save(footballMatch);
+            updateLeagueIfSeasonFinished(footballMatch);
             return "redirect:/game-week/all/" + footballMatch.getGameWeek().getLeague().getId();
         }
         simulate15Minutes(footballMatch); //
@@ -300,5 +308,32 @@ public class FootballMatchService {
                 footballMatch.getGameWeek() == null || footballMatch.getAwayTeam().getLineUp() == null ||
                 footballMatch.getHomeTeam().getLineUp() == null) return false;
         return true;
+    }
+
+    private void updateLeagueIfSeasonFinished(FootballMatch footballMatch) {
+        League league = footballMatch.getGameWeek().getLeague();
+        if (league == null || league.getGameWeekList() == null) {
+            return;
+        }
+        boolean allFinished = true;
+        for (GameWeek gameWeek : league.getGameWeekList()) {
+            if (gameWeek.getMatchList() == null) {
+                allFinished = false;
+                break;
+            }
+            for (FootballMatch match : gameWeek.getMatchList()) {
+                if (!Status.FINISHED.equals(match.getMatchStatus())) {
+                    allFinished = false;
+                    break;
+                }
+            }
+            if (!allFinished) {
+                break;
+            }
+        }
+        if (allFinished) {
+            league.setLeagueStatus(Status.FINISHED);
+            leagueRepository.save(league);
+        }
     }
 }

--- a/src/main/java/com/example/FootballSimulator/GameWeek/GameWeekManager.java
+++ b/src/main/java/com/example/FootballSimulator/GameWeek/GameWeekManager.java
@@ -70,7 +70,7 @@ public class GameWeekManager {
 
     public static List<GameWeek> shuffleGameWeekList(List<GameWeek> gameWeekList) {
         int size = gameWeekList.size();
-        List<GameWeek> shuffledGameWeekList = Arrays.asList(new GameWeek[size]);
+        List<GameWeek> shuffledGameWeekList = new ArrayList<>(Collections.nCopies(size, (GameWeek) null));
         List<GameWeek> firstHalf = gameWeekList.subList(0, size / 2);
         List<GameWeek> secondHalf = gameWeekList.subList(size / 2, size);
         for (int i = 0; i < size / 2; i++) {

--- a/src/main/java/com/example/FootballSimulator/League/League.java
+++ b/src/main/java/com/example/FootballSimulator/League/League.java
@@ -3,6 +3,7 @@ package com.example.FootballSimulator.League;
 import com.example.FootballSimulator.Constants.Status;
 import com.example.FootballSimulator.FootballTeam.FootballTeam;
 import com.example.FootballSimulator.GameWeek.GameWeek;
+import com.example.FootballSimulator.Season.Season;
 import com.example.FootballSimulator.Standings.Standing;
 import jakarta.persistence.*;
 
@@ -35,6 +36,11 @@ public class League {
 
     @OneToMany(mappedBy = "league")
     private List<Standing> standings;
+
+    private Integer currentSeason;
+
+    @OneToMany(mappedBy = "league")
+    private List<Season> seasons;
 
     public Long getId() {
         return id;
@@ -82,5 +88,21 @@ public class League {
 
     public void setStandings(List<Standing> standings) {
         this.standings = standings;
+    }
+
+    public Integer getCurrentSeason() {
+        return currentSeason;
+    }
+
+    public void setCurrentSeason(Integer currentSeason) {
+        this.currentSeason = currentSeason;
+    }
+
+    public List<Season> getSeasons() {
+        return seasons;
+    }
+
+    public void setSeasons(List<Season> seasons) {
+        this.seasons = seasons;
     }
 }

--- a/src/main/java/com/example/FootballSimulator/League/LeagueController.java
+++ b/src/main/java/com/example/FootballSimulator/League/LeagueController.java
@@ -36,6 +36,11 @@ public class LeagueController {
         return leagueService.startLeague(leagueId, model);
     }
 
+    @GetMapping("/new-season/{leagueId}")
+    public String startNewSeason(@PathVariable Long leagueId, Model model) {
+        return leagueService.startNewSeason(leagueId, model);
+    }
+
     @GetMapping("/select")
     public String selectLeague(Model model) {
         return leagueService.selectLeague(model);

--- a/src/main/java/com/example/FootballSimulator/League/LeagueService.java
+++ b/src/main/java/com/example/FootballSimulator/League/LeagueService.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -183,6 +184,7 @@ public class LeagueService {
         return "/league/select";
     }
 
+    @Transactional
     public String startNewSeason(Long leagueId, Model model) {
         Optional<League> optionalLeague = leagueRepository.findById(leagueId);
         if (optionalLeague.isEmpty()) {

--- a/src/main/java/com/example/FootballSimulator/League/LeagueService.java
+++ b/src/main/java/com/example/FootballSimulator/League/LeagueService.java
@@ -1,20 +1,19 @@
 package com.example.FootballSimulator.League;
 
-import com.example.FootballSimulator.BaseFootballPlayer.BaseFootballPlayer;
-import com.example.FootballSimulator.BaseFootballPlayer.BaseFootballPlayerRepository;
 import com.example.FootballSimulator.BaseFootballTeam.BaseFootballTeam;
 import com.example.FootballSimulator.BaseFootballTeam.BaseFootballTeamRepository;
 import com.example.FootballSimulator.Constants.Role;
 import com.example.FootballSimulator.Constants.Status;
 import com.example.FootballSimulator.FootballMatch.FootballMatch;
 import com.example.FootballSimulator.FootballMatch.FootballMatchRepository;
-import com.example.FootballSimulator.FootballPlayer.FootballPlayer;
-import com.example.FootballSimulator.FootballPlayer.FootballPlayerRepository;
 import com.example.FootballSimulator.FootballTeam.FootballTeam;
 import com.example.FootballSimulator.FootballTeam.FootballTeamRepository;
 import com.example.FootballSimulator.GameWeek.GameWeek;
 import com.example.FootballSimulator.GameWeek.GameWeekManager;
 import com.example.FootballSimulator.GameWeek.GameWeekRepository;
+import com.example.FootballSimulator.Season.Season;
+import com.example.FootballSimulator.Season.SeasonRepository;
+import com.example.FootballSimulator.Season.SeasonStanding;
 import com.example.FootballSimulator.Standings.Standing;
 import com.example.FootballSimulator.Standings.StandingRepository;
 import com.example.FootballSimulator.User.User;
@@ -26,9 +25,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -43,19 +42,16 @@ public class LeagueService {
     @Autowired
     private FootballTeamRepository footballTeamRepository;
     @Autowired
-    private FootballPlayerRepository footballPlayerRepository;
-
-    @Autowired
     private GameWeekRepository gameWeekRepository;
 
     @Autowired
     private FootballMatchRepository footballMatchRepository;
     @Autowired
-    private BaseFootballPlayerRepository baseFootballPlayerRepository;
-    @Autowired
     private UserRepository userRepository;
     @Autowired
     private StandingRepository standingRepository;
+    @Autowired
+    private SeasonRepository seasonRepository;
 
     public String addLeague(Model model) {
         model.addAttribute("league", new League());
@@ -90,6 +86,7 @@ public class LeagueService {
             return "/league/addLeague";
         }
 
+        league.setCurrentSeason(1);
         leagueRepository.save(league);
         List<FootballTeam> footballTeamList = new ArrayList<>();
         for (int i = 0; i < selectedFootballTeams.size(); i++) {
@@ -121,6 +118,9 @@ public class LeagueService {
         if (optionalLeague.isPresent()) {
             League league = optionalLeague.get();
             if (getCheckMessageIfLeagueIsAbleToStart(league) == null) {
+                if (league.getCurrentSeason() == null) {
+                    league.setCurrentSeason(1);
+                }
                 league.setLeagueStatus(Status.STARTED);
                 leagueRepository.save(league);
                 addStandings(league);
@@ -181,5 +181,130 @@ public class LeagueService {
         List<League> leagueList = leagueRepository.findAllByLeagueStatus(Status.STARTED);
         model.addAttribute("leagues", leagueList);
         return "/league/select";
+    }
+
+    public String startNewSeason(Long leagueId, Model model) {
+        Optional<League> optionalLeague = leagueRepository.findById(leagueId);
+        if (optionalLeague.isEmpty()) {
+            model.addAttribute("message", "No such league!");
+            model.addAttribute("getAllLeagues", leagueRepository.findAll());
+            return "/league/getLeagues";
+        }
+        League league = optionalLeague.get();
+        if (!Status.FINISHED.equals(league.getLeagueStatus())) {
+            model.addAttribute("message", "The league must be finished before starting a new season!");
+            model.addAttribute("getAllLeagues", leagueRepository.findAll());
+            return "/league/getLeagues";
+        }
+        archiveSeason(league);
+        resetLeagueForNewSeason(league);
+        model.addAttribute("message", "New season started successfully!");
+        model.addAttribute("getAllLeagues", leagueRepository.findAll());
+        return "/league/getLeagues";
+    }
+
+    private void archiveSeason(League league) {
+        Season season = new Season();
+        season.setLeague(league);
+        Integer currentSeason = league.getCurrentSeason();
+        if (currentSeason == null || currentSeason < 1) {
+            currentSeason = 1;
+        }
+        season.setSeasonNumber(currentSeason);
+        season.setFinishedAt(LocalDateTime.now());
+        season.setStatus(Status.FINISHED);
+        List<Standing> standings = league.getStandings();
+        if (standings != null && !standings.isEmpty()) {
+            List<Standing> sortedStandings = standings.stream()
+                    .sorted((s1, s2) -> {
+                        int pointsComparison = Integer.compare(
+                                s2.getPoints() == null ? 0 : s2.getPoints(),
+                                s1.getPoints() == null ? 0 : s1.getPoints());
+                        if (pointsComparison != 0) {
+                            return pointsComparison;
+                        }
+                        int s1Goals = s1.getScoredGoals() == null ? 0 : s1.getScoredGoals();
+                        int s2Goals = s2.getScoredGoals() == null ? 0 : s2.getScoredGoals();
+                        return Integer.compare(s2Goals, s1Goals);
+                    })
+                    .collect(Collectors.toList());
+            List<SeasonStanding> seasonStandings = new ArrayList<>();
+            int position = 1;
+            for (Standing standing : sortedStandings) {
+                SeasonStanding seasonStanding = new SeasonStanding();
+                seasonStanding.setSeason(season);
+                seasonStanding.setFootballTeam(standing.getFootballTeam());
+                seasonStanding.setPoints(standing.getPoints() == null ? 0 : standing.getPoints());
+                seasonStanding.setPlayedMatches(standing.getPlayedMatches() == null ? 0 : standing.getPlayedMatches());
+                seasonStanding.setScoredGoals(standing.getScoredGoals() == null ? 0 : standing.getScoredGoals());
+                seasonStanding.setConcededGoals(standing.getConcededGoals() == null ? 0 : standing.getConcededGoals());
+                seasonStanding.setPosition(position++);
+                seasonStandings.add(seasonStanding);
+            }
+            season.setStandings(seasonStandings);
+        }
+        seasonRepository.save(season);
+    }
+
+    private void resetLeagueForNewSeason(League league) {
+        clearSchedule(league);
+        resetStandings(league);
+        Integer currentSeason = league.getCurrentSeason();
+        if (currentSeason == null) {
+            currentSeason = 1;
+        }
+        league.setCurrentSeason(currentSeason + 1);
+        GameWeekManager gameWeekManager = new GameWeekManager();
+        List<GameWeek> gameWeekList = gameWeekManager.generateGameWeeks(league);
+        league.setGameWeekList(gameWeekList);
+        for (GameWeek gameWeek : gameWeekList) {
+            gameWeekRepository.save(gameWeek);
+            List<FootballMatch> matchList = gameWeek.getMatchList();
+            if (matchList != null) {
+                for (FootballMatch match : matchList) {
+                    footballMatchRepository.save(match);
+                }
+            }
+        }
+        league.setLeagueStatus(Status.STARTED);
+        leagueRepository.save(league);
+    }
+
+    private void clearSchedule(League league) {
+        List<GameWeek> gameWeeks = league.getGameWeekList();
+        if (gameWeeks == null) {
+            return;
+        }
+        List<GameWeek> copyGameWeeks = new ArrayList<>(gameWeeks);
+        for (GameWeek gameWeek : copyGameWeeks) {
+            List<FootballMatch> matches = gameWeek.getMatchList();
+            if (matches != null && !matches.isEmpty()) {
+                List<FootballMatch> copyMatches = new ArrayList<>(matches);
+                for (FootballMatch match : copyMatches) {
+                    match.setGameWeek(null);
+                }
+                footballMatchRepository.deleteAll(copyMatches);
+            }
+        }
+        for (GameWeek gameWeek : copyGameWeeks) {
+            gameWeek.setMatchList(new ArrayList<>());
+            gameWeek.setLeague(null);
+        }
+        gameWeekRepository.deleteAll(copyGameWeeks);
+        league.setGameWeekList(new ArrayList<>());
+    }
+
+    private void resetStandings(League league) {
+        List<Standing> standings = league.getStandings();
+        if (standings == null) {
+            return;
+        }
+        for (Standing standing : standings) {
+            standing.setPoints((byte) 0);
+            standing.setScoredGoals((short) 0);
+            standing.setConcededGoals((short) 0);
+            standing.setPlayedMatches((byte) 0);
+            standingRepository.save(standing);
+        }
     }
 }

--- a/src/main/java/com/example/FootballSimulator/Season/Season.java
+++ b/src/main/java/com/example/FootballSimulator/Season/Season.java
@@ -1,0 +1,78 @@
+package com.example.FootballSimulator.Season;
+
+import com.example.FootballSimulator.Constants.Status;
+import com.example.FootballSimulator.League.League;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+public class Season {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "league_id")
+    private League league;
+
+    private Integer seasonNumber;
+
+    private LocalDateTime finishedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @OneToMany(mappedBy = "season", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SeasonStanding> standings;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public League getLeague() {
+        return league;
+    }
+
+    public void setLeague(League league) {
+        this.league = league;
+    }
+
+    public Integer getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public void setSeasonNumber(Integer seasonNumber) {
+        this.seasonNumber = seasonNumber;
+    }
+
+    public LocalDateTime getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(LocalDateTime finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public List<SeasonStanding> getStandings() {
+        return standings;
+    }
+
+    public void setStandings(List<SeasonStanding> standings) {
+        this.standings = standings;
+    }
+}

--- a/src/main/java/com/example/FootballSimulator/Season/SeasonRepository.java
+++ b/src/main/java/com/example/FootballSimulator/Season/SeasonRepository.java
@@ -1,0 +1,8 @@
+package com.example.FootballSimulator.Season;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeasonRepository extends CrudRepository<Season, Long> {
+}

--- a/src/main/java/com/example/FootballSimulator/Season/SeasonStanding.java
+++ b/src/main/java/com/example/FootballSimulator/Season/SeasonStanding.java
@@ -1,0 +1,94 @@
+package com.example.FootballSimulator.Season;
+
+import com.example.FootballSimulator.FootballTeam.FootballTeam;
+import jakarta.persistence.*;
+
+@Entity
+public class SeasonStanding {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "season_id")
+    private Season season;
+
+    @ManyToOne
+    @JoinColumn(name = "football_team_id")
+    private FootballTeam footballTeam;
+
+    private byte points;
+
+    private byte playedMatches;
+
+    private short scoredGoals;
+
+    private short concededGoals;
+
+    private int position;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Season getSeason() {
+        return season;
+    }
+
+    public void setSeason(Season season) {
+        this.season = season;
+    }
+
+    public FootballTeam getFootballTeam() {
+        return footballTeam;
+    }
+
+    public void setFootballTeam(FootballTeam footballTeam) {
+        this.footballTeam = footballTeam;
+    }
+
+    public byte getPoints() {
+        return points;
+    }
+
+    public void setPoints(byte points) {
+        this.points = points;
+    }
+
+    public byte getPlayedMatches() {
+        return playedMatches;
+    }
+
+    public void setPlayedMatches(byte playedMatches) {
+        this.playedMatches = playedMatches;
+    }
+
+    public short getScoredGoals() {
+        return scoredGoals;
+    }
+
+    public void setScoredGoals(short scoredGoals) {
+        this.scoredGoals = scoredGoals;
+    }
+
+    public short getConcededGoals() {
+        return concededGoals;
+    }
+
+    public void setConcededGoals(short concededGoals) {
+        this.concededGoals = concededGoals;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+}

--- a/src/main/resources/templates/league/getLeagues.html
+++ b/src/main/resources/templates/league/getLeagues.html
@@ -55,6 +55,7 @@
       <th>Game Weeks</th>
       <th th:if="${#authorization.expression('hasRole(''ROLE_USER'')')}">View Standings</th>
       <th th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}">Start League</th>
+      <th th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}">Start New Season</th>
     </tr>
     </thead>
     <tbody>
@@ -66,6 +67,9 @@
       <td><a class="btn btn-info" th:href="@{/game-week/all/{leagueId}(leagueId=${league.id})}">Game weeks</a></td>
       <td th:if="${#authorization.expression('hasRole(''ROLE_USER'')')}"><a class="btn btn-success" th:href="@{/standings/view/{leagueId}(leagueId=${league.id})}">View standings</a></td>
       <td th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"><a class="btn btn-danger" th:href="@{/league/start/{leagueId}(leagueId=${league.id})}">Start League</a></td>
+      <td th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')') and league.leagueStatus == T(com.example.FootballSimulator.Constants.Status).FINISHED}">
+        <a class="btn btn-warning" th:href="@{/league/new-season/{leagueId}(leagueId=${league.id})}">Start New Season</a>
+      </td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- add Season and SeasonStanding entities to persist completed season results for each league
- extend league lifecycle to track the current season, archive standings, and regenerate fixtures when starting a new season
- mark leagues as finished once all matches are complete and expose a "Start New Season" action in the leagues panel

## Testing
- `./mvnw test` *(fails: network is unreachable when downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b9e9ab988320ae8f59df501ae65e